### PR TITLE
v2.0.4+2: fix package not showing support for all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [2.0.4+2]
+* fix package not showing support for Android, iOS, Windows, Linux & macOS on pub.dev. 
 ## [2.0.4+1]
 * merged pull#18 [Remove redundant configuration. ](https://github.com/ozyl/flutter_lyric/pull/18) 
 ## [2.0.4]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_lyric
-description: This plugin is a music lyric reader,support highlight,translation lyrics,smooth animation,custom UI,Parse.;
-version: 2.0.4+1
+description: A music lyric reader that supports highlight, translation lyrics, smooth animation, custom UI & parsing.
+version: 2.0.4+2
 homepage: https://github.com/ozyl/flutter_lyric
 email: zylvip@163.com
 
@@ -11,12 +11,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_web_plugins:
-    sdk: flutter
   collection: ^1.15.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
I have changed to package's description to following if you don't mind.

> A music lyric reader that supports highlight, translation lyrics, smooth animation, custom UI & parsing.

## Changes

* Bump version to v2.0.4+2
* Fix package not showing support for all platforms.
  * Remove `flutter_web_plugins` from `dependencies`.
  * Add `uses-material-design` in `flutter` entry.
