### PR TITLE
Fix animation before first line starts

### DIFF
--- a/lib/lyrics_reader_widget.dart
+++ b/lib/lyrics_reader_widget.dart
@@ -496,11 +496,9 @@ class LyricReaderState extends State<LyricsReader>
       }
       var begin = width += (ratio * element.drawWidth);
       firstBegin ??= begin;
-      if (element.duration > 0) {
-        items.add(TweenSequenceItem(
-            tween: Tween(begin: begin, end: width += element.drawWidth),
-            weight: element.duration.toDouble()));
-      }
+      items.add(TweenSequenceItem(
+          tween: Tween(begin: begin, end: width += element.drawWidth),
+          weight: element.duration.toDouble()));
     }
     disposeHighlight();
     if (items.isEmpty) {


### PR DESCRIPTION
Tween animation is wrong if `position < lines[0].startTime`. In this situation, animation duration is `lineDuration - duration`, which is actually equal to the time of all spans untweened in that line. After calculation, the animation starts. But the true time should be `line.endTime - position` because `line.startTime is larger than position`.

第一行歌词的动画效果存在一些问题。如果当前的 position 处于当前行的 startTime 之前，那么动画的整体显示时间计算是比实际时间要短的。