### PR TITLE
fix(LrcParser): 支持冒号格式时间戳，兼容 [00:00:58] 格式的歌词(如https://music.163.com/…

### DIFF
--- a/lib/core/lyric_parse.dart
+++ b/lib/core/lyric_parse.dart
@@ -53,7 +53,7 @@ class LrcParser extends LyricParse {
   @override
   bool isMatch(String mainLyric) {
     return RegExp(
-      r'^\[(\d{1,}):(\d{2})(?:\.(\d{1,}))?\]',
+      r'^\[(\d{1,}):(\d{2})(?:[.:](\d{1,}))?\]',
       multiLine: true,
     ).hasMatch(mainLyric);
   }
@@ -126,7 +126,7 @@ class LrcParser extends LyricParse {
 
   static LrcLine? extractLine(String line) {
     final regexp = RegExp(
-      r'\[(\d{1,}):(\d{2})(?:\.(\d{1,}))?\]',
+      r'\[(\d{1,}):(\d{2})(?:[.:](\d{1,}))?\]',
       multiLine: true,
     );
     final matches = regexp.allMatches(line);


### PR DESCRIPTION
如https://music.163.com/#/song?id=2133659925